### PR TITLE
Deprecating Vocabs SPARQL service; changing ACDH to ACDH-CH

### DIFF
--- a/view/fundament_about.inc
+++ b/view/fundament_about.inc
@@ -1,20 +1,15 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-sm-12">
-            <h4>About Vocabs</h4>
-            <p>In many areas of scholarly work, controlled vocabularies (gazetteers, thesauri, etc.) play a crucial role as a stable reference for resources and for ensuring interoperability between disparate projects and their data. The ACDH provides services and tools that allow for collaborative creation, maintenance and publication of vocabularies and taxonomies of any kind. </p>
-        </div>
-    </div>
-</div>
-<br>
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-sm-12">
-            <h4 id="repository">Vocabs repository</h4>
-            <p>The system is based on the open-source software <a href="http://skosmos.org/">Skosmos</a>, which uses <a href="https://www.w3.org/TR/2009/REC-skos-reference-20090818/">SKOS</a> as the underlying data model. Skosmos offers browsing of vocabularies with structured concept displays and visualisation of concept hierarchies. Vocabularies can be searched with a search interface or by consulting an alphabetical or thematic index. Vocabularies can be accessed via a REST-API, to allow for Linked Data. </p>
-     
+            <h4>Vocabs services</h4>
             <p>
-                Vocabs repository does not only serve controlled vocabularies for ACDH purposes, but is also employed as a service for partners of the national <a href="http://www.digital-humanities.at/en">CLARIAH-AT</a> consortium, for the <a href="https://www.dariah.eu/activities/working-groups/thesaurus-maintenance/">Thesaurus Maintenance</a> working group in <a href="https://www.dariah.eu/">DARIAH-EU</a>, and for <a href="http://www.parthenos-project.eu/activities-and-wps">WP6 - Services and tools</a> in <a href="http://www.parthenos-project.eu/">PARTHENOS</a>. 
+                In many areas of scholarly work, controlled vocabularies (gazetteers, thesauri, etc.) play a crucial role as a stable reference for resources and for ensuring interoperability between disparate projects and their data. The ACDH-CH provides services and tools that allow for collaborative creation, maintenance and publication of vocabularies and taxonomies of any kind.
+            </p>
+            <p>
+                Vocabs browse service is based on the open-source software <a href="https://skosmos.org/">Skosmos</a>, which uses <a href="https://www.w3.org/TR/2009/REC-skos-reference-20090818/">SKOS</a> as the underlying data model. Skosmos offers browsing of vocabularies with structured concept displays and visualisation of concept hierarchies. Vocabularies can be searched with a search interface or by consulting an alphabetical or thematic index. Vocabularies can be accessed via a REST-API, to allow for Linked Data.
+            </p>
+            <p>
+                Vocabs services does not only serve controlled vocabularies for ACDH-CH purposes, but is also employed as a service for partners of the national <a href="https://clariah.at/">CLARIAH-AT</a> consortium, for the <a href="https://www.dariah.eu/activities/working-groups/thesaurus-maintenance/">Thesaurus Maintenance</a> working group in DARIAH-EU, and in general as a service of <a href="https://www.dariah.eu/">DARIAH-EU</a> where it can also be accessed at <a href="https://vocabs.dariah.eu">https://vocabs.dariah.eu</a>.
             </p>
         </div>
     </div>
@@ -46,30 +41,6 @@
             <div class="text-center h-100">
                 <img class="img-responsive" src="./resource/pics/vocabseditor_01.png">
             </div>
-        </div>
-    </div>
-</div>
-<br>
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-sm-12">
-            <h4 id="sparql">Vocabs SPARQL</h4>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-5 pr-2">
-            <div class="text-center">
-                <img class="img-responsive" src="./resource/pics/sparql-01.png">
-            </div>
-        </div>
-        <div class="col-sm-5 h-100 pl-2">
-            <p>
-                <a href="https://github.com/acdh-oeaw/djangobaseproject">DjangoBaseProject</a> and allows to query all published vocabularies using SPARQL.<br>
-
-                A read-only access to Jena Fuseki triple store via SPARQL endpoint.
-                The service is based on <a href="https://vocabs-sparql.acdh.oeaw.ac.at/">Visit Vocabs SPARQL</a>
-
-            </p>
         </div>
     </div>
 </div>

--- a/view/fundament_footer.twig
+++ b/view/fundament_footer.twig
@@ -6,7 +6,7 @@
         <div class="row">
             <div class="footer-widget col-lg-1 col-md-2 col-sm-2 col-xs-6 col-3">
                 <div class="textwidget custom-html-widget">
-                    <a href="/"><img src="https://fundament.acdh.oeaw.ac.at/common-assets/images/acdh_logo.svg" class="image" alt="ACDH Logo" style="max-width: 100%; height: auto;" title="ACDH Logo"></a>
+                    <a href="/"><img src="https://fundament.acdh.oeaw.ac.at/common-assets/images/acdh_logo.svg" class="image" alt="ACDH-CH Logo" style="max-width: 100%; height: auto;" title="ACDH Logo"></a>
                 </div>
             </div>
             <!-- .footer-widget -->

--- a/view/fundament_header_hero.twig
+++ b/view/fundament_header_hero.twig
@@ -3,7 +3,7 @@
         <div id="wrapper-hero-inner" class="container hero-dark">
             <h1>Vocabs services</h1>
             <p class="lead">
-                In many areas of scholarly work, controlled vocabularies (gazetteers, thesauri, etc.) play a crucial role as a stable reference for resources and for ensuring interoperability between disparate projects and their data. The ACDH provides a suite of Vocabs services that allow for collaborative creation, maintenance and publication of vocabularies and taxonomies of any kind.            
+                In many areas of scholarly work, controlled vocabularies (gazetteers, thesauri, etc.) play a crucial role as a stable reference for resources and for ensuring interoperability between disparate projects and their data. The ACDH-CH provides a suite of Vocabs services that allow for collaborative creation, maintenance and publication of vocabularies and taxonomies of any kind.
             </p>
         </div>
 

--- a/view/fundament_topbar.twig
+++ b/view/fundament_topbar.twig
@@ -21,11 +21,6 @@
         </a>
     </li>
      <li class="nav-item"> 
-        <a href="{% if request.vocabid and vocab.title%}{{ request.vocabid }}/{% endif %}{{ request.lang }}/about#sparql{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi3" class="nav-link navigation-font">
-            {% trans "SPARQL" %}
-        </a>
-    </li>
-     <li class="nav-item"> 
         <a href="{% if request.vocabid and vocab.title%}{{ request.vocabid }}/{% endif %}{{ request.lang }}/about#api{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi3" class="nav-link navigation-font">
             {% trans "API" %}
         </a>


### PR DESCRIPTION
## Reasons for creating this PR

Vocabs SPARQL service is deprecated. While doing this also discovered some old text that needed to be changed, especially using ACDH-CH instead of ACDH

## Link to relevant issue(s), if any

- Closes #3 

